### PR TITLE
Disallow overriding undefined apps

### DIFF
--- a/lib/baustelle/config/validator.rb
+++ b/lib/baustelle/config/validator.rb
@@ -13,6 +13,7 @@ module Baustelle
 
       def call(config_hash)
         RSchema.validation_error(schema(config_hash), config_hash)
+        validate_app_overrides(config_hash)
       end
 
       private
@@ -141,6 +142,17 @@ module Baustelle
             'environments' => Hash
           }
         }
+      end
+
+      def validate_app_overrides(config_hash)
+        allowed_apps = config_hash.fetch('applications', {}).keys
+
+        config_hash.fetch('environments', {}).each do |env, env_config|
+          undefined_apps = (env_config.fetch('applications', {}).keys - allowed_apps)
+          unless undefined_apps.empty?
+            raise "Environment #{env} tries to override not existing apps #{undefined_apps.inspect}"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Last week we've got a "rollback" failed indirectly because of
naming mismatch between the root config and the environment
override