### PR TITLE
IO-40: Use elasticbeanstalk URLs again

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ baustelle script infrastructure_graph --region=eu-west-1 --name=yana 1>graph.jso
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/doc/02-yaml/02-applications.md
+++ b/doc/02-yaml/02-applications.md
@@ -27,6 +27,7 @@ applications:
       https: true
       ssl_certificate: arn:aws:iam::123456789012:server-certificate/baustelle_com
       ssl_reference_policy: ELBSecurityPolicy-2015-05
+    hostname_scheme: old
     dns:
       name: user-profile-service.baustelle.org
       hosted_zone: baustelle.org.
@@ -109,6 +110,13 @@ The AWS ARN of the ssl certificate to use for HTTPS.
 The AWS SSL reference policy to use. This only configures the SSL ciphers in the loadbalancer that are safe to use.
 AWS creates new updated policies regularily, so always try to keep this value to the most recent policy available.
 * required when `applications.<app_name>.elb.https=true`
+
+#### `applications.<app_name>.hostname_scheme`
+AWS changed the hostname scheme of elasticbeanstalk applications. Old applications that were created before a certain date have the scheme
+`<cname>.elasticbeanstalk.com` and new applications have the scheme `<cname>.<region>.elasticbeanstalk.com`. In order to inject the right
+application URL when using application references, we must tell baustelle which hostname scheme the application uses. For new applications
+you do not need to worry and skip this option. For applications that still use the old scheme, set this to `old`.
+* optional, possible values: (`old`, `new`), defaults to `new`
 
 #### `applications.<app_name>.dns.name`
 An optional dns name that will point to the loadbalancer of the application. If not given, the application can still be reached

--- a/lib/baustelle/config/application.rb
+++ b/lib/baustelle/config/application.rb
@@ -32,6 +32,10 @@ module Baustelle
         @raw.fetch('elb', {})
       end
 
+      def new_hostname_scheme?
+        @raw.fetch('hostname_scheme', 'new') == 'new'
+      end
+
       def elb_visibility
         elb.fetch('visibility', 'external')
       end

--- a/lib/baustelle/config/validator/application.rb
+++ b/lib/baustelle/config/validator/application.rb
@@ -49,6 +49,7 @@ module Baustelle
               String => ConfigEntry.new(applications: applications,
                                         backends: backends)
             ),
+            optional('hostname_scheme') => enum(%w(old new)),
             optional('disabled') => boolean,
             optional('pre_deploy_test_command') => String,
             optional('systemtests') => either(enum(applications),

--- a/lib/baustelle/jenkins/application.rb
+++ b/lib/baustelle/jenkins/application.rb
@@ -78,7 +78,6 @@ module Baustelle
               eb_env_name(@name, @application, @environment),
             eb_application_name: "#{@name}-#{@application}".gsub('-', '_').underscore.camelize,
             application_version_source: @application_version_source,
-            endpoint: "#{@name}-#{@region}-#{@environment}-#{@application}.elasticbeanstalk.com".gsub('_', '-'),
             system_test_job_name: system_test_job_name
           }
         )

--- a/lib/baustelle/stack_template.rb
+++ b/lib/baustelle/stack_template.rb
@@ -108,6 +108,7 @@ module Baustelle
           unless app_config.disabled?
             resource_name = CloudFormation::EBEnvironment.apply(template,
                                                                 stack_name: name,
+                                                                region: region,
                                                                 env_name: env_name,
                                                                 app_ref: app.ref(template),
                                                                 app_name: app.name,

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -89,6 +89,7 @@ applications:
       DATABASE_URL: backend(External:postgres:url)
       CUSTOM_HELLO_URL: application(custom_hello_world:url)
       HTTPS_APP_URL: application(https_hello_world:url)
+      OLD_HOSTNAME_SCHEME_APP: application(hello_world_old_hostname_scheme:url)
   https_hello_world:
     stack: ruby2.2-with-datadog
     instance_type: t2.small
@@ -100,6 +101,13 @@ applications:
     dns:
       hosted_zone: example.com
       name: app.example.com
+  hello_world_old_hostname_scheme:
+    stack: ruby2.2-with-datadog
+    instance_type: t2.small
+    hostname_scheme: old
+    scale:
+      min: 1
+      max: 1
   application_not_in_loadtest:
     stack: ruby
     instance_type: t2.small
@@ -437,7 +445,18 @@ environments:
           app_env = option_settings["aws:elasticbeanstalk:application:environment"]
           expect(app_env["CUSTOM_HELLO_URL"]).
             to eq({'Fn::Join' =>
-                   ['', ['http://', 'custom-hello-world.production.app.baustelle.internal']]
+                   ['', ['http://', 'foo-us-east-1-production-custom-hello-world.us-east-1.elasticbeanstalk.com']]
+                  })
+        end
+      end
+
+      it 'links application using the old elasticbeanstalk url scheme' do
+        expect_resource template, "HelloWorldEnvProduction" do |properties|
+          option_settings = group_option_settings(properties[:OptionSettings])
+          app_env = option_settings["aws:elasticbeanstalk:application:environment"]
+          expect(app_env["OLD_HOSTNAME_SCHEME_APP"]).
+            to eq({'Fn::Join' =>
+                   ['', ['http://', 'foo-us-east-1-production-hello-world-old-hostname-scheme.elasticbeanstalk.com']]
                   })
         end
       end


### PR DESCRIPTION
when referencing other applications in order to be able to remove DNS entry resource now that we already hit the maximum limit of cloudformation resources

**DO NOT MERGE BEFORE https://github.com/upday/deployment/pull/163**