### PR TITLE
IO-40: Remove internal dns resources for applications

### DIFF
--- a/lib/baustelle/cloud_formation/ebenvironment.rb
+++ b/lib/baustelle/cloud_formation/ebenvironment.rb
@@ -125,9 +125,6 @@ module Baustelle
                             }
                           }.tap { |res| res[:DependsOn] = chain_after if chain_after }
 
-        InternalDNS.cname(template, internal_dns, name: "#{app_name}.#{env_name}.app",
-                          target: {'Fn::GetAtt' => [resource_name, 'EndpointURL']})
-
         resource_name
       end
 

--- a/spec/baustelle/stack_template/application.rb
+++ b/spec/baustelle/stack_template/application.rb
@@ -30,18 +30,6 @@ shared_examples "Application in environment" do |stack_name:, environment:, app_
       end
     end
 
-    it "CNAME" do
-      expect_cname template, [app_name.gsub('_', '-'),
-                              environment.gsub('_', '-'),
-                              'app.baustelle.internal'].join('.'),
-                   {'Fn::GetAtt' => [camelized_app_name + "Env" + camelized_environment,
-                                    'EndpointURL']}
-
-      expect_cname template, /^#{app_name.gsub('_', '-')}.#{environment.gsub('_', '-')}.app.foo.[\w-]+.baustelle.internal$/,
-                   {'Fn::GetAtt' => [camelized_app_name + "Env" + camelized_environment,
-                                    'EndpointURL']}
-    end
-
     it "ElasticBeanstalk Environment" do
       expect_resource template, camelized_app_name + "Env" + camelized_environment,
                       of_type: "AWS::ElasticBeanstalk::Environment" do |properties|


### PR DESCRIPTION
now that we use elasticbeanstalk URLs again.

**DO NOT MERGE BEFORE https://github.com/upday/baustelle/pull/64 IS FULLY DEPLOYED TO PROD**