### PR TITLE
Remove internal DNS entries of backends

### DIFF
--- a/lib/baustelle/backend/base.rb
+++ b/lib/baustelle/backend/base.rb
@@ -13,12 +13,6 @@ module Baustelle
       private
 
       attr_reader :name, :options, :vpc, :parent_iam_role, :internal_dns
-
-      def cname(template, name, target, **kwargs)
-        Baustelle::CloudFormation::InternalDNS.cname(template, @internal_dns,
-                                                     name: name, target: target,
-                                                     **kwargs)
-      end
     end
   end
 end

--- a/lib/baustelle/backend/postgres.rb
+++ b/lib/baustelle/backend/postgres.rb
@@ -2,8 +2,6 @@ module Baustelle
   module Backend
     class Postgres < Base
       def build(template)
-        cname(template, [name, 'postgres', 'backend'], host)
-
         template.resource sg = "#{prefix}SubnetGroup",
                           Type: 'AWS::RDS::DBSubnetGroup',
                           Properties: {

--- a/lib/baustelle/backend/rabbitmq.rb
+++ b/lib/baustelle/backend/rabbitmq.rb
@@ -2,14 +2,11 @@ module Baustelle
   module Backend
     class RabbitMQ < Base
       def build(template)
-
         options.fetch('ami').each do |region, ami|
           template.add_to_region_mapping "BackendAMIs", region, ami_name, ami
         end
 
         prefix = "RabbitMQ#{name.camelize}"
-
-        cname(template, [name, 'rabbitmq', 'backend'], host)
 
         template.resource lc = "#{prefix}LaunchConfiguration",
                           Type: 'AWS::AutoScaling::LaunchConfiguration',

--- a/lib/baustelle/backend/redis.rb
+++ b/lib/baustelle/backend/redis.rb
@@ -2,8 +2,6 @@ module Baustelle
   module Backend
     class Redis < Base
       def build(template)
-        cname(template, [name, 'redis', 'backend'], host)
-
         template.resource sg = "#{prefix}SubnetGroup",
                           Type: 'AWS::ElastiCache::SubnetGroup',
                           Properties: {

--- a/lib/baustelle/cloud_formation/internal_dns.rb
+++ b/lib/baustelle/cloud_formation/internal_dns.rb
@@ -28,25 +28,6 @@ module Baustelle
         OpenStruct.new(id: resource_name, domain: root_domain)
       end
 
-      def cname(template, zones, name:, target:, ttl: 60)
-        cname = Array(name).map(&:underscore).
-               map { |s| s.gsub('_', '-') }.
-               join('.')
-        Array(zones).each do |zone|
-          resource_name = ["Entry#{zone.id}", cname_to_resource_name(cname)].
-                          flatten.map(&:camelize).join
-          template.resource resource_name,
-                            Type: 'AWS::Route53::RecordSet',
-                            Properties: {
-                              HostedZoneId: template.ref(zone.id),
-                              Type: 'CNAME',
-                              TTL: ttl,
-                              ResourceRecords: [target],
-                              Name: "#{cname}.#{zone.domain}"
-                            }
-        end
-      end
-
       private
 
       def cname_to_resource_name(cname)

--- a/spec/baustelle/stack_template/backend/rabbitmq.rb
+++ b/spec/baustelle/stack_template/backend/rabbitmq.rb
@@ -41,14 +41,5 @@ shared_examples "Backend RabbitMQ in environment" do  |stack_name:, environment:
       end
     end
 
-    it 'internal DNS' do
-      expect_cname template, "#{environment}-#{name}.rabbitmq.backend.baustelle.internal",
-                   {'Fn::GetAtt' => ["RabbitMQ#{camelized_environment}#{camelized_name}ELB",
-                                     'DNSName']}
-
-      expect_cname template, /^#{environment}-#{name}.rabbitmq.backend.foo.[\w-]+.baustelle.internal$/,
-                   {'Fn::GetAtt' => ["RabbitMQ#{camelized_environment}#{camelized_name}ELB",
-                                     'DNSName']}
-    end
   end
 end

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -190,19 +190,6 @@ environments:
     yield resource[:Properties], resource if block_given?
   end
 
-  def expect_cname(template, cname, target)
-    declared_cnames = template[:Resources].select { |key,_| key =~ /^Entry.*DNSZone/ }
-    _, declared_cname = declared_cnames.find { |_, entry|
-      case cname
-      when Regexp then entry[:Properties][:Name] =~ cname
-      else entry[:Properties][:Name] == cname
-      end
-    }
-    expect(declared_cname).not_to be_nil, "CNAME #{cname} is not declared. declared CNAMES are: \n\t#{declared_cnames.map { |_, e| e[:Properties][:Name] }.join("\n\t")}"
-    expect(declared_cname[:Properties][:ResourceRecords]).
-      to eq([target])
-  end
-
   def ref(name)
     {'Ref' => name}
   end


### PR DESCRIPTION
to further reduce Cloudformation resources