### PR TITLE
add miscellaneous application config for passing arbitrary stuff to jenkins job templates

### DIFF
--- a/doc/02-yaml/02-applications.md
+++ b/doc/02-yaml/02-applications.md
@@ -50,6 +50,8 @@ applications:
           - kinesis:GetShardIterator
           - kinesis:GetRecords
         resource: backend(Kinesis:user_events:arn)
+    miscellaneous:
+      foo: bar
 
 
   another_application:
@@ -185,3 +187,7 @@ In this case baustelle will take care of replacing the reference with an ARN
 for every environment.
 Note that if the specific ARN is given here, it is possible to override it on
 per-environment basis.
+
+### `applications.<app_name>.miscellaneous`
+A hash with any key value pairs that are ignored by baustelle but accessible in jenkins jobs
+via `app_config.miscellaneous.<key>`.

--- a/lib/baustelle/config/validator/application.rb
+++ b/lib/baustelle/config/validator/application.rb
@@ -90,7 +90,8 @@ module Baustelle
                 'action' => either(String, [String])
               }
             ),
-            optional('new_environment_naming') => boolean
+            optional('new_environment_naming') => boolean,
+            optional('miscellaneous') => Hash,
           }
         end
 


### PR DESCRIPTION
i want to add slack usernames and description to the jenkins job but do not want to modify the baustelle validator every time