### PR TITLE
autoscaling-trigger

### DIFF
--- a/lib/baustelle/config/validator/application.rb
+++ b/lib/baustelle/config/validator/application.rb
@@ -49,6 +49,7 @@ module Baustelle
             optional('trigger') => {
               'measure_name' => enum(RSchema::AWSAutoscalingTriggers::MEASURES),
               'breach_duration' => Fixnum,
+              'period' => Fixnum,
               'lower_threshold' => Float,
               'upper_threshold' => Float,
               'unit' => enum(RSchema::AWSAutoscalingTriggers::UNITS),

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -150,6 +150,7 @@ applications:
     trigger:
       measure_name: Latency
       breach_duration: 2
+      period: 2
       lower_threshold: 1
       upper_threshold: 2
       unit: Seconds
@@ -621,6 +622,9 @@ environments:
             expect(measure_name.length).to eq(1)
             expect(measure_name[0][:Value]).to eq('Latency')
             breach_duration = (trigger_options.select{|options| options[:OptionName] == 'BreachDuration'})
+            expect(breach_duration.length).to eq (1)
+            expect(breach_duration[0][:Value]).to eq("2")
+            breach_duration = (trigger_options.select{|options| options[:OptionName] == 'Period'})
             expect(breach_duration.length).to eq (1)
             expect(breach_duration[0][:Value]).to eq("2")
             lower_threshold = (trigger_options.select{|options| options[:OptionName] == 'LowerThreshold'})


### PR DESCRIPTION
Add Period value, to specify how frequently cloudwatch measures the metrics for the autoscaling trigger