### PR TITLE
install ansible 1.9.3

### DIFF
--- a/lib/baustelle/ami/packer_template.rb
+++ b/lib/baustelle/ami/packer_template.rb
@@ -65,7 +65,9 @@ module Baustelle
           ]
         when 'amazon'
           [
-            "sudo pip install ansible --upgrade",
+            # wasn't able to install the most recent ansible version on amazon linux because of missing dependencies.
+            # quickfix: use old ansible version
+            "sudo pip install 'ansible<2.0.0'",
           ]
         else
           raise "Unsupported base system"


### PR DESCRIPTION
the most recent one (2.1.0) couldnt be installed on amazon linux because of missing dependencies. Don't have the time now to find the proper solution