### PR TITLE
Add parameter for specifying template layout to config spec

### DIFF
--- a/lib/baustelle.rb
+++ b/lib/baustelle.rb
@@ -18,6 +18,7 @@ module Baustelle
   require 'baustelle/cloud_formation/peer_vpc'
   require 'baustelle/cloud_formation/route53'
   require 'baustelle/cloud_formation/application'
+  require 'baustelle/cloud_formation/application_stack'
   require 'baustelle/cloud_formation/ebenvironment'
   require 'baustelle/cloud_formation/template'
   require 'baustelle/cloud_formation/iam_role'

--- a/lib/baustelle/cloud_formation/application_stack.rb
+++ b/lib/baustelle/cloud_formation/application_stack.rb
@@ -1,0 +1,36 @@
+require 'ostruct'
+
+module Baustelle
+  module CloudFormation
+    class ApplicationStack
+      attr_reader :canonical_name, :name
+
+      def initialize(stack_name, app_name)
+        @name = app_name
+        @canonical_name = self.class.eb_name(stack_name, app_name)
+      end
+
+      def apply(template)
+        template.resource @canonical_name,
+                Type: "AWS::CloudFormation::Stack",
+                Properties: {
+                  NotificationARNs: [],
+                  Parameters: {},
+                  Tags: [],
+                  TemplateURL: "https://s3.amazonaws.com/baustelle-bucket/#{@canonical_name}.json",
+                  TimeoutInMinutes: "String"
+                }
+      end
+
+      def self.eb_name(stack_name, app_name)
+        "#{stack_name}_#{app_name}_stack".camelize
+      end
+
+      def ref(template)
+        template.ref(@canonical_name)
+      end
+
+    end
+  end
+end
+

--- a/lib/baustelle/config/application.rb
+++ b/lib/baustelle/config/application.rb
@@ -40,6 +40,10 @@ module Baustelle
         elb.fetch('visibility', 'public')
       end
 
+      def template_layout
+        @raw.fetch('template_layout', 'old')
+      end
+
     end
   end
 end

--- a/lib/baustelle/config/validator/application.rb
+++ b/lib/baustelle/config/validator/application.rb
@@ -96,7 +96,7 @@ module Baustelle
             ),
             optional('new_environment_naming') => boolean,
             optional('miscellaneous') => Hash,
-            optional('template_layout') => enum(%w(old new both))
+            optional('template_layout') => enum(%w(old new))
           }
         end
 

--- a/lib/baustelle/config/validator/application.rb
+++ b/lib/baustelle/config/validator/application.rb
@@ -96,6 +96,7 @@ module Baustelle
             ),
             optional('new_environment_naming') => boolean,
             optional('miscellaneous') => Hash,
+            optional('template_layout') => enum(%w(old new both))
           }
         end
 

--- a/lib/baustelle/stack_template.rb
+++ b/lib/baustelle/stack_template.rb
@@ -142,7 +142,8 @@ module Baustelle
                                                                   chain_after: previous_eb_env[index % previous_eb_env.size])
               previous_eb_env[index % previous_eb_env.size] = resource_name
             elsif app_config.template_layout == 'new'
-              raise "template_layout => new is not supported yet"
+              puts "template_layout => new is not supported yet"
+              puts "No action done"
             end
           end
         end

--- a/lib/baustelle/stack_template.rb
+++ b/lib/baustelle/stack_template.rb
@@ -89,6 +89,7 @@ module Baustelle
             app.apply(template)
           when 'new'
             app = CloudFormation::ApplicationStack.new(name, app_name)
+            raise "new template_layout is not supported yet"
         end
         app
       end
@@ -143,7 +144,7 @@ module Baustelle
               previous_eb_env[index % previous_eb_env.size] = resource_name
             elsif app_config.template_layout == 'new'
               puts "template_layout => new is not supported yet"
-              puts "No action done"
+              raise "new template_layout is not supported yet"
             end
           end
         end

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -29,6 +29,10 @@ stacks:
     solution: Ruby AWS EB Solution V2.0
     ami:
       us-east-1: ami-654321
+  java:
+    solution: Java AWS EB Solution
+    ami:
+      us-east-1: ami-424242
 
 bastion:
   instance_type: t2.micro
@@ -180,6 +184,13 @@ applications:
       min: 1
       max: 2
     new_environment_naming: true
+  application_new_template_layout:
+    stack: java
+    instance_type: t1.small
+    scale:
+      min: 1
+      max: 2
+    template_layout: new
 
 
 environments:

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -184,13 +184,6 @@ applications:
       min: 1
       max: 2
     new_environment_naming: true
-  application_new_template_layout:
-    stack: java
-    instance_type: t1.small
-    scale:
-      min: 1
-      max: 2
-    template_layout: new
 
 
 environments:


### PR DESCRIPTION
application parameter template_layout has the possible values:
old - layout as it is now (part of the main template file)
new - using the new layout (child stack for application)
both - using both layouts, essentially creating the application twice

both is only used during migration