### PR TITLE
Build template just before uploading it

### DIFF
--- a/lib/baustelle/cloud_formation/application_stack.rb
+++ b/lib/baustelle/cloud_formation/application_stack.rb
@@ -5,9 +5,10 @@ module Baustelle
     class ApplicationStack
       attr_reader :canonical_name, :name
 
-      def initialize(stack_name, app_name)
+      def initialize(stack_name, app_name, bucket_name)
         @name = app_name
         @canonical_name = self.class.eb_name(stack_name, app_name)
+        @bucket_name = bucket_name
       end
 
       def apply(template)
@@ -17,7 +18,7 @@ module Baustelle
                   NotificationARNs: [],
                   Parameters: {},
                   Tags: [],
-                  TemplateURL: "https://s3.amazonaws.com/baustelle-bucket/#{@canonical_name}.json",
+                  TemplateURL: "https://s3.amazonaws.com/#{@bucket_name}/#{@canonical_name}.json",
                   TimeoutInMinutes: "String"
                 }
       end

--- a/lib/baustelle/cloud_formation/remote_template.rb
+++ b/lib/baustelle/cloud_formation/remote_template.rb
@@ -7,12 +7,16 @@ module Baustelle
     class RemoteTemplate
       attr_reader :bucket
 
-      def initialize(region:,
+      def initialize(stack_name,
+                     region:,
                      bucket: Baustelle::WorkspaceBucket.new(region: region).call)
         @bucket = bucket
+        @region = region
+        @stack_name = stack_name
       end
 
       def call(template)
+        template.build(@stack_name, @region, @bucket.name)
         file.put(body: template.to_json)
         main_temlate_url = file.public_url
         template.childs.each do |child|

--- a/lib/baustelle/commands/create.rb
+++ b/lib/baustelle/commands/create.rb
@@ -7,10 +7,10 @@ module Baustelle
 
       def call(specification_file, region:, name:)
         config = Baustelle::Config.read(specification_file)
-        template = Baustelle::StackTemplate.new(config).build(name, region)
+        template = Baustelle::StackTemplate.new(config)
 
         Aws.config[:region] = region
-        Baustelle::CloudFormation::RemoteTemplate.new(region: region).
+        Baustelle::CloudFormation::RemoteTemplate.new(stack_name: name, region: region).
           call(template.to_json) do |template_url|
           Baustelle::CloudFormation.create_stack(name, template_url) or exit(1)
         end

--- a/lib/baustelle/commands/print_cloudformation_template.rb
+++ b/lib/baustelle/commands/print_cloudformation_template.rb
@@ -7,7 +7,7 @@ module Baustelle
 
       def call(specification_file, region:, name:)
         config = Baustelle::Config.read(specification_file)
-        template = Baustelle::StackTemplate.new(config).build(name, region)
+        template = Baustelle::StackTemplate.new(config).build(name, region, "baustelle-workspace-bucket")
 
         puts template.to_json
       end

--- a/lib/baustelle/commands/update.rb
+++ b/lib/baustelle/commands/update.rb
@@ -7,10 +7,10 @@ module Baustelle
 
       def call(specification_file, region:, name:)
         config = Baustelle::Config.read(specification_file)
-        template = Baustelle::StackTemplate.new(config).build(name, region)
+        template = Baustelle::StackTemplate.new(config)
 
         Aws.config[:region] = region
-        Baustelle::CloudFormation::RemoteTemplate.new(region: region).
+        Baustelle::CloudFormation::RemoteTemplate.new(stack_name: name, region: region).
           call(template) do |template_url|
           Baustelle::CloudFormation.update_stack(name, template_url) or exit(1)
         end

--- a/lib/baustelle/stack_template.rb
+++ b/lib/baustelle/stack_template.rb
@@ -6,7 +6,7 @@ module Baustelle
       @config = config
     end
 
-    def build(name, region, template: CloudFormation::Template.new)
+    def build(name, region, bucket_name, template: CloudFormation::Template.new)
       # Prepare VPC
       vpc = CloudFormation::VPC.apply(template, vpc_name: name,
                                       cidr_block: config.fetch('vpc').fetch('cidr'),
@@ -84,7 +84,7 @@ module Baustelle
             app = CloudFormation::Application.new(name, app_name)
             app.apply(template)
           when 'new'
-            app = CloudFormation::ApplicationStack.new(name, app_name)
+            app = CloudFormation::ApplicationStack.new(name, app_name, bucket_name)
             raise "new template_layout is not supported yet"
         end
         app

--- a/lib/baustelle/workspace_bucket.rb
+++ b/lib/baustelle/workspace_bucket.rb
@@ -12,10 +12,6 @@ module Baustelle
       bucket_object(find_bucket || create_bucket)
     end
 
-    def empty_bucket
-      bucket_object(find_bucket).clear
-    end
-
     private
 
     def bucket_object(bucket)

--- a/spec/baustelle/cloud_formation/remote_template_spec.rb
+++ b/spec/baustelle/cloud_formation/remote_template_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Baustelle::CloudFormation::RemoteTemplate do
   describe '#call' do
     let(:template) { Baustelle::CloudFormation::RemoteTemplate.
-                     new(region: 'us-east-1', bucket: bucket) }
+                     new('baustelle', region: 'us-east-1', bucket: bucket) }
 
-    let(:bucket) { double(object: object, clear!: nil) }
+    let(:bucket) { double(object: object, clear!: nil, name: 'bautelle-workspace-bucket') }
     let(:object) { spy(put: nil, public_url: 'url') }
     let(:stack_template) { spy('Baustelle::StackTemplate', childs: [], to_json: '{}') }
 

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -259,7 +259,7 @@ environments:
 
   describe '#build' do
     let(:region) { 'us-east-1' }
-    subject { stack_template.build("foo", region) }
+    subject { stack_template.build("foo", region, "bucket") }
 
     context "returns template" do
       let(:template) { (subject.as_json) }


### PR DESCRIPTION
The template is now build when the remoteTemplate uploads it into a
S3 bucket. This is needed because the Nested stack needs to know the
bucket name for the URL reference.