### PR TITLE
Add m4 cache instance types

### DIFF
--- a/lib/rschema/aws_instance_type.rb
+++ b/lib/rschema/aws_instance_type.rb
@@ -15,6 +15,7 @@ d2.xlarge d2.2xlarge d2.4xlarge d2.8xlarge),
 cache.m1.medium
 cache.t2.micro cache.t2.small cache.t2.medium
 cache.m3.medium cache.m3.large cache.m3.xlarge cache.m3.2xlarge
+cache.m4.large cache.m4.xlarge cache.m4.2xlarge cache.m4.4xlarge cache.m4.10xlarge
 cache.r3.large cache.r3.xlarge cache.r3.2xlarge cache.r3.4xlarge cache.r3.8xlarge
 ),
       rds: %w(


### PR DESCRIPTION
The m4 instance types were missing that's why validation fails
if m4 cache instances are used.