### PR TITLE
Clear S3 bucket after waiting for completion

### DIFF
--- a/lib/baustelle/cli.rb
+++ b/lib/baustelle/cli.rb
@@ -21,6 +21,7 @@ module Baustelle
                                               name: name)
       ensure
         Baustelle::Commands::Wait.call(name: name, region: region)
+        Baustelle::Commands::ClearBucket.call(region: region, name: name)
       end
 
     end
@@ -36,6 +37,7 @@ module Baustelle
                                               name: name)
       ensure
         Baustelle::Commands::Wait.call(name: name, region: region)
+        Baustelle::Commands::ClearBucket.call(region: region, name: name)
       end
 
     end

--- a/lib/baustelle/commands/clear_bucket.rb
+++ b/lib/baustelle/commands/clear_bucket.rb
@@ -1,0 +1,14 @@
+module Baustelle
+  module Commands
+    module ClearBucket
+      extend self
+
+      def call(region:, name:)
+        Aws.config[:region] = region
+        remote_template = Baustelle::CloudFormation::RemoteTemplate.new(name, region: region)
+        remote_template.clear_bucket
+        puts "Cleared S3 bucket"
+      end
+    end
+  end
+end

--- a/spec/baustelle/cloud_formation/remote_template_spec.rb
+++ b/spec/baustelle/cloud_formation/remote_template_spec.rb
@@ -5,7 +5,7 @@ describe Baustelle::CloudFormation::RemoteTemplate do
     let(:template) { Baustelle::CloudFormation::RemoteTemplate.
                      new('baustelle', region: 'us-east-1', bucket: bucket) }
 
-    let(:bucket) { double(object: object, clear!: nil, name: 'bautelle-workspace-bucket') }
+    let(:bucket) { double(object: object, clear!: nil, name: 'bautelle-workspace-bucket', url: '') }
     let(:object) { spy(put: nil, public_url: 'url') }
     let(:cloudformation_template) { spy('CloudFormation::Template', childs: {}, to_json: '{}') }
     let(:stack_template) { spy('Baustelle::StackTemplate', build: cloudformation_template) }
@@ -27,11 +27,5 @@ describe Baustelle::CloudFormation::RemoteTemplate do
       template.call(stack_template) {}
     end
 
-    it 'deletes the remote file after the block' do
-      template.call(stack_template) do
-        expect(bucket).not_to have_received(:clear!)
-      end
-      expect(bucket).to have_received(:clear!)
-    end
   end
 end


### PR DESCRIPTION
In order to not delete the templates to early the S3 bucket is
cleared after the Cloudformation stack is finished with its
tasks.