### PR TITLE
Generate a unique template url

### DIFF
--- a/lib/baustelle/cloud_formation/application_stack.rb
+++ b/lib/baustelle/cloud_formation/application_stack.rb
@@ -5,12 +5,13 @@ module Baustelle
     class ApplicationStack
       attr_reader :canonical_name, :name
 
-      def initialize(stack_name, app_name, bucket_url)
+      def initialize(stack_name, app_name, bucket_url, main_template_uuid)
         @name = app_name
         @canonical_name = self.class.eb_name(stack_name, app_name)
         @bucket_url = bucket_url
         @stack_name = stack_name
         @application_template_iam_role = nil
+        @main_template_uuid = main_template_uuid
       end
 
       def apply(template, vpc)
@@ -27,7 +28,7 @@ module Baustelle
                     {Key: 'stack', Value: "#{@stack_name}"},
                     {Key: 'canonical-name', Value: "#{@canonical_name}"}
                   ],
-                  TemplateURL: "#{@bucket_url}/#{@canonical_name}.json",
+                  TemplateURL: "#{@bucket_url}/#{@canonical_name}-#{@main_template_uuid}.json",
                 }
         parameters.keys.each { |name|
           if [:Subnets].include?(name)

--- a/lib/baustelle/cloud_formation/remote_template.rb
+++ b/lib/baustelle/cloud_formation/remote_template.rb
@@ -16,12 +16,13 @@ module Baustelle
       end
 
       def call(template)
-        stack_template = template.build(@stack_name, @region, @bucket.url)
-        main_template_s3object = file
+        main_template_uuid = SecureRandom.uuid
+        stack_template = template.build(@stack_name, @region, @bucket.url, main_template_uuid)
+        main_template_s3object = file(main_template_uuid)
         main_template_s3object.put(body: stack_template.to_json)
         main_temlate_url = main_template_s3object.public_url
         stack_template.childs.each do |child_name, child_template|
-          child_template_s3object = file(child_name)
+          child_template_s3object = file("#{child_name}-#{main_template_uuid}")
           child_template_s3object.put(body: child_template.to_json)
         end
         yield main_temlate_url
@@ -33,7 +34,7 @@ module Baustelle
 
       private
 
-      def file(name = SecureRandom.uuid)
+      def file(name)
         @bucket.object(name + ".json")
       end
     end

--- a/lib/baustelle/stack_template.rb
+++ b/lib/baustelle/stack_template.rb
@@ -6,7 +6,7 @@ module Baustelle
       @config = config
     end
 
-    def build(name, region, bucket_name, template: CloudFormation::Template.new)
+    def build(name, region, bucket_name, main_template_uuid, template: CloudFormation::Template.new)
       # Prepare VPC
       vpc = CloudFormation::VPC.apply(template, vpc_name: name,
                                       cidr_block: config.fetch('vpc').fetch('cidr'),
@@ -84,7 +84,7 @@ module Baustelle
             app = CloudFormation::Application.new(name, app_name)
             app.apply(template)
           when 'new'
-            app = CloudFormation::ApplicationStack.new(name, app_name, bucket_name)
+            app = CloudFormation::ApplicationStack.new(name, app_name, bucket_name, main_template_uuid)
             app.apply(template, vpc)
         end
         app

--- a/spec/baustelle/stack_template/new_layout.rb
+++ b/spec/baustelle/stack_template/new_layout.rb
@@ -3,7 +3,7 @@ shared_examples "New template layout" do
     it 'Creates a stack resource' do
       expect_resource template, "FooNewLayoutNewlayout",
                       of_type: 'AWS::CloudFormation::Stack' do |properties, resource|
-        expect(properties[:TemplateURL]).to eq('https://s3.amazonaws.com/bucket/FooNewLayoutNewlayout.json')
+        expect(properties[:TemplateURL]).to eq('https://s3.amazonaws.com/bucket/FooNewLayoutNewlayout-UUID.json')
         parameters = properties[:Parameters]
         tags = properties[:Tags]
         expect(parameters[:VPC]).to eq(ref('foo'))
@@ -22,7 +22,7 @@ shared_examples "New template layout" do
         fetch('production', nil).
         fetch('applications', {}).
         fetch('new_layout_NewLayout', {})['template_layout'] = 'old'
-      expect {Baustelle::StackTemplate.new(error_config).build("foo", region, "bucket")}.to raise_error(RuntimeError)
+      expect {Baustelle::StackTemplate.new(error_config).build("foo", region, "bucket", 'UUID')}.to raise_error(RuntimeError)
     end
 
     it 'Creates child template' do
@@ -33,7 +33,7 @@ shared_examples "New template layout" do
 
     context 'child template' do
       let(:region) { 'us-east-1' }
-      let(:parent_template) { stack_template.build("foo", region, "bucket") }
+      let(:parent_template) { stack_template.build("foo", region, "bucket", 'UUID') }
       subject { parent_template.childs['FooNewLayoutNewlayout'] }
       let(:template) { (subject.as_json) }
 

--- a/spec/baustelle/stack_template_spec.rb
+++ b/spec/baustelle/stack_template_spec.rb
@@ -268,7 +268,7 @@ environments:
 
   describe '#build' do
     let(:region) { 'us-east-1' }
-    subject { stack_template.build("foo", region, "https://s3.amazonaws.com/bucket") }
+    subject { stack_template.build("foo", region, "https://s3.amazonaws.com/bucket", 'UUID') }
 
     context "returns template" do
       let(:template) { (subject.as_json) }


### PR DESCRIPTION
To ensure the child stack are update on every update run
the template url uses the UUID/name od the main template
as suffix. This way the template url is different on every
run.