### PR TITLE
updated nokogiri gem to 1.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in platform.gemspec
 gemspec
-gem "nokogiri", "1.8.2"
+gem 'nokogiri', '~> 1.10', '>= 1.10.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    baustelle (0.1.0)
+    baustelle (0.1.1)
       activesupport (~> 4.2.5)
       aws-sdk
       jenkins_api_client (~> 1.5.3)
@@ -637,12 +637,12 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     mixlib-shellout (2.3.2)
     nenv (0.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -685,9 +685,9 @@ DEPENDENCIES
   baustelle!
   bundler (~> 1.10)
   guard-rspec
-  nokogiri (= 1.8.2)
+  nokogiri (~> 1.10, >= 1.10.1)
   rake (~> 10.0)
   rspec
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/lib/baustelle/version.rb
+++ b/lib/baustelle/version.rb
@@ -1,3 +1,3 @@
 module Baustelle
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
fixed the vulnerability warning. specs have been run and there are no issues reported.